### PR TITLE
m3u8: used only acceptable characters for Content-Type

### DIFF
--- a/src/serviceapp/m3u8.cpp
+++ b/src/serviceapp/m3u8.cpp
@@ -173,7 +173,7 @@ int M3U8VariantsExplorer::getVariantsFromMasterUrl(const std::string& url, const
         if (!contentTypeParsed)
         {
             char contenttype[33];
-            if (sscanf(lineBuffer, "Content-Type: %32s", contenttype) == 1)
+            if (sscanf(lineBuffer, "Content-Type: %32[a-zA-Z/.-]", contenttype) == 1)
             {
                 contentTypeParsed = true;
                 if (!strcasecmp(contenttype, "application/text")


### PR DESCRIPTION
I found the stream with Content-Type: application/vnd.apple.mpegurl; charset=utf-8
Which causes the error: not supported contenttype detected: application/vnd.apple.mpegurl;

This should fix it.

P.S.
I'm not a good coder.
Maybe you find a better solution.
Maybe need compare the specific length of text?