### PR TITLE
m3u8: fix find M3U8 header if before it is not emty lines

### DIFF
--- a/src/serviceapp/m3u8.cpp
+++ b/src/serviceapp/m3u8.cpp
@@ -212,15 +212,11 @@ int M3U8VariantsExplorer::getVariantsFromMasterUrl(const std::string& url, const
         if (!m3u8HeaderParsed)
         {
             // find M3U8 header
-            if (!result || strncmp(lineBuffer, M3U8_HEADER, strlen(M3U8_HEADER)))
-            {
-                continue;
-            }
-            else
+            if (result && !strncmp(lineBuffer, M3U8_HEADER, strlen(M3U8_HEADER)))
             {
                 m3u8HeaderParsed = true;
-                continue;
             }
+            continue;
         }
 
         if (!strncmp(lineBuffer, M3U8_MEDIA_SEQUENCE, strlen(M3U8_MEDIA_SEQUENCE)))

--- a/src/serviceapp/m3u8.cpp
+++ b/src/serviceapp/m3u8.cpp
@@ -211,14 +211,10 @@ int M3U8VariantsExplorer::getVariantsFromMasterUrl(const std::string& url, const
         contentSize += result + 1; // newline char
         if (!m3u8HeaderParsed)
         {
-            // skip empty lines
-            if (!result)
-                continue;
-
-            if (strncmp(lineBuffer, M3U8_HEADER, strlen(M3U8_HEADER)))
+            // find M3U8 header
+            if (!result || strncmp(lineBuffer, M3U8_HEADER, strlen(M3U8_HEADER)))
             {
-                fprintf(stderr, "[%s] - invalid m3u8 file, missing '%s' header\n", __func__, M3U8_HEADER);
-                break;
+                continue;
             }
             else
             {


### PR DESCRIPTION
I found not working m3u8 with following structure:
...
X-Request-Id: 2fd891a8-865d-4b46-aa77-c85c79dc6730
X-Runtime: 0.006990

262
#EXTM3U
#EXT-X-STREAM-INF:RESOLUTION=640x272,BANDWIDTH=376000
...