### PR TITLE
m3u8: parse Content-Length only if not set and not m3u8HeaderParsed

### DIFF
--- a/src/serviceapp/m3u8.cpp
+++ b/src/serviceapp/m3u8.cpp
@@ -183,7 +183,12 @@ int M3U8VariantsExplorer::getVariantsFromMasterUrl(const std::string& url, const
             ret = 0;
             break;
         }
-        sscanf(lineBuffer, "Content-Length: %d", &contentLength);
+
+        if (!contentLength && !m3u8HeaderParsed)
+        {
+            sscanf(lineBuffer, "Content-Length: %d", &contentLength);
+        }
+
         if (!contentTypeParsed)
         {
             char contenttype[33];

--- a/src/serviceapp/m3u8.cpp
+++ b/src/serviceapp/m3u8.cpp
@@ -184,7 +184,7 @@ int M3U8VariantsExplorer::getVariantsFromMasterUrl(const std::string& url, const
             break;
         }
 
-        if (!contentLength && !m3u8HeaderParsed)
+        if (!contentLength && !contentStarted)
         {
             sscanf(lineBuffer, "Content-Length: %d", &contentLength);
         }


### PR DESCRIPTION
I assume that the Content-Length is specified once.
If the content part started, also then Content-Length should no longer be.

Therefore,  not necessary parse it at every read.