### PR TITLE
Add possibility to delete all playable files in movielist

### DIFF
--- a/src/serviceapp/serviceapp.h
+++ b/src/serviceapp/serviceapp.h
@@ -191,6 +191,6 @@ public:
 	RESULT record(const eServiceReference &, ePtr<iRecordableService> &ptr){ptr=0;return -1;};
 	RESULT list(const eServiceReference &, ePtr<iListableService> &ptr){ptr=0;return -1;};
 	RESULT info(const eServiceReference &, ePtr<iStaticServiceInformation> &ptr){ptr=m_service_info; return 0;};
-	RESULT offlineOperations(const eServiceReference &, ePtr<iServiceOfflineOperations> &ptr){ptr=0;return -1;};
+	RESULT offlineOperations(const eServiceReference &, ePtr<iServiceOfflineOperations> &ptr);
 };
 #endif


### PR DESCRIPTION
Based on: https://github.com/OpenPLi/enigma2/commit/c2065c013a7cd519374f5179ea71a3416cea9a3f

This fix error if user delete file on exit when stop movie:
  File /usr/lib/enigma2/python/Screens/InfoBar.py, line 311, in leavePlayerConfirmed
  AttributeError: 'NoneType' object has no attribute 'deleteFromDisk'