### PR TITLE
serviceapp: start in runlevel service+3

### DIFF
--- a/src/serviceapp/serviceapp.cpp
+++ b/src/serviceapp/serviceapp.cpp
@@ -1411,7 +1411,7 @@ eServiceFactoryApp::~eServiceFactoryApp()
 }
 
 
-eAutoInitPtr<eServiceFactoryApp> init_eServiceFactoryApp(eAutoInitNumbers::service+1, "eServiceFactoryApp");
+eAutoInitPtr<eServiceFactoryApp> init_eServiceFactoryApp(eAutoInitNumbers::service+3, "eServiceFactoryApp");
 
 
 static PyObject *


### PR DESCRIPTION
Make sure we are initialized after servicemp3 (service+1) and
servicemp3 replacements (service+2).

This fixes a race with servicemp3 loaded from a shared object.
(serviceapp requires servicemp3 to be initialized)