### PR TITLE
Revert part of 6b0e5665baac7498b344cb745c0d6347c0078cd6

### DIFF
--- a/src/serviceapp/serviceapp.h
+++ b/src/serviceapp/serviceapp.h
@@ -128,7 +128,7 @@ public:
 	RESULT audioDelay(ePtr<iAudioDelay> &ptr){ ptr=0; return -1;};
 	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr){ ptr=0; return -1;};
 	RESULT stream(ePtr<iStreamableService> &ptr){ ptr=0; return -1;};
-	RESULT streamed(ePtr<iStreamedService> &ptr){ ptr=this; return 0;};
+	RESULT streamed(ePtr<iStreamedService> &ptr){ ptr=0; return -1;};
 	RESULT keys(ePtr<iServiceKeys> &ptr){ ptr=0; return -1;};
 	void setQpipMode(bool value, bool audio){};
 


### PR DESCRIPTION
It seems this is not an ePtr<iStreamedService> like in https://github.com/OpenPLi/servicemp3/blob/master/servicemp3/servicemp3.cpp#L2978

This commit will fix the following error:
../../../git/src/serviceapp/serviceapp.h: In member function 'virtual RESULT eServiceApp::streamed(ePtr<iStreamedService>&)':
../../../git/src/serviceapp/serviceapp.h:131:52: error: no match for 'operator=' (operand types are 'ePtr<iStreamedService>' and 'eServiceApp*')
  RESULT streamed(ePtr<iStreamedService> &ptr){ ptr=this; return 0;};