### PR TITLE
serviceapp: return sServiceref string without removing path

### DIFF
--- a/src/serviceapp/serviceapp.cpp
+++ b/src/serviceapp/serviceapp.cpp
@@ -1291,12 +1291,7 @@ std::string eServiceApp::getInfoString(int w)
 		case sProvider:
 			return "IPTV";
 		case sServiceref:
-		{
-			eServiceReference ref(m_ref);
-			ref.type = m_ref.type;
-			ref.path.clear();
-			return ref.toString();
-		}
+			return m_ref.toString();
 		default:
 			break;
 		}


### PR DESCRIPTION
When sServiceref is requested on getInfoString it will return
the service without removing the path. Just like do in servicedvb.