### PR TITLE
serviceapp: add handler for sSID on getInfo

### DIFF
--- a/src/serviceapp/serviceapp.cpp
+++ b/src/serviceapp/serviceapp.cpp
@@ -1276,6 +1276,7 @@ int eServiceApp::getInfo(int w)
 		}
 		return resNA;
 	}
+	case sSID: return m_ref.getData(1);
 	default:
 		return resNA;
 	}


### PR DESCRIPTION
This commit will return the SID stored on eServiceReference.data[1]
when sSID information requested.

Related: https://devtools.openpli.org/issues/216