### PR TITLE
serviceapp: always handle sServiceref on getInfoString

### DIFF
--- a/src/serviceapp/serviceapp.cpp
+++ b/src/serviceapp/serviceapp.cpp
@@ -1285,18 +1285,16 @@ int eServiceApp::getInfo(int w)
 
 std::string eServiceApp::getInfoString(int w)
 {
-	if ( strstr(m_ref.path.c_str(), "://") )
+	switch (w)
 	{
-		switch (w)
-		{
-		case sProvider:
-			return "IPTV";
-		case sServiceref:
-			return m_ref.toString();
-		default:
-			break;
-		}
+	case sProvider:
+		return m_ref.path.find("://") != std::string::npos ? "IPTV" : "FILE";
+	case sServiceref:
+		return m_ref.toString();
+	default:
+		break;
 	}
+
 	if (w < sUser && w > 26 )
 		return "";
 	switch(w)


### PR DESCRIPTION
When sServiceref was used for local files, getInfoString returns an empty string
making checks expecting data returned from getInfoString to fail.

This commit will handle sServiceref for all media types.
Additionally, this commit will return "FILE" as a provider for local files.