### PR TITLE
exteplayer3: add suburi support in service reference

### DIFF
--- a/src/serviceapp/exteplayer3.cpp
+++ b/src/serviceapp/exteplayer3.cpp
@@ -137,7 +137,17 @@ std::vector<std::string> ExtEplayer3::buildCommand()
 	// TODO add all options
 	std::vector<std::string> args;
 	args.push_back("exteplayer3");
-	args.push_back(mPath);
+	size_t pos = mPath.find("&suburi=");
+	if (pos != std::string::npos)
+	{
+		args.push_back(mPath.substr(0, pos));
+		args.push_back("-x");
+		args.push_back(mPath.substr(pos + 8));
+	}
+	else
+	{
+		args.push_back(mPath);
+	}
 	std::map<std::string,std::string>::const_iterator i(mHeaders.find("User-Agent"));
 	if (i != mHeaders.end())
 	{


### PR DESCRIPTION
This allows pecify an additional audio stream using suburi parameter in service reference path string.
https://github.com/OpenPLi/enigma2/commit/65962a39625aaf02f66ee9258181ec2d164916a6
https://github.com/OpenPLi/enigma2/commit/a6e9e2fd0aa2ee8ed9c4f00cb355b8d8e18f6e7a

I use this in my plugin youtube to play DASH streams.
And I'm tired explaining to simple users who use exteplayer3 as the default enigma2 player for other plugins, why exteplayer3 does not work with my plugin, and suburi support does not have a serviceapp bug.

This is my commit cherry pick from branch develop.
Some commands use branch master while some branch develop.
Therefore, this option does not work for everyone.
I do not know if you maintain this project.
If you do not plan to merge develop in branch master maybe you can find time to add this commit with merge this PR.